### PR TITLE
feat: Fix all xfail/xpass tests for AddAfterEOF

### DIFF
--- a/server/test/unit/test_add_after_eof.py
+++ b/server/test/unit/test_add_after_eof.py
@@ -112,7 +112,7 @@ class TestAddAfterEOF:
         
         assert extracted == secret
     
-    @pytest.mark.xfail
+
     def test_read_secret_no_watermark_raises_error(self, sample_pdf_bytes: bytes):
         """Test reading from non-watermarked PDF raises SecretNotFoundError."""
         method = AddAfterEOF()
@@ -120,7 +120,7 @@ class TestAddAfterEOF:
         with pytest.raises(SecretNotFoundError, match="No AddAfterEOF watermark found"):
             method.read_secret(sample_pdf_bytes, "any-key")
     
-    @pytest.mark.xfail
+
     def test_read_secret_wrong_key_raises_error(self, sample_pdf_bytes: bytes):
         """Test reading with wrong key raises InvalidKeyError."""
         method = AddAfterEOF()
@@ -206,7 +206,7 @@ class TestAddAfterEOF:
         
         assert payload1 == payload2
     
-    @pytest.mark.xfail
+
     def test_corrupted_payload_raises_error(self, sample_pdf_bytes: bytes):
         """Test corrupted payload raises SecretNotFoundError."""
         method = AddAfterEOF()
@@ -222,7 +222,7 @@ class TestAddAfterEOF:
         with pytest.raises(SecretNotFoundError, match="Malformed watermark payload"):
             method.read_secret(corrupted, key)
     
-    @pytest.mark.xfail
+
     def test_empty_payload_raises_error(self, sample_pdf_bytes: bytes):
         """Test empty payload raises SecretNotFoundError."""
         method = AddAfterEOF()
@@ -233,7 +233,7 @@ class TestAddAfterEOF:
         with pytest.raises(SecretNotFoundError, match="Found marker but empty payload"):
             method.read_secret(watermarked, "any-key")
     
-    @pytest.mark.xfail
+
     def test_unsupported_version_raises_error(self, sample_pdf_bytes: bytes):
         """Test unsupported version raises SecretNotFoundError."""
         method = AddAfterEOF()
@@ -248,7 +248,7 @@ class TestAddAfterEOF:
         with pytest.raises(SecretNotFoundError, match="Unsupported watermark version"):
             method.read_secret(watermarked, "any-key")
     
-    @pytest.mark.xfail
+
     def test_unsupported_mac_algorithm_raises_error(self, sample_pdf_bytes: bytes):
         """Test unsupported MAC algorithm raises WatermarkingError."""
         method = AddAfterEOF()
@@ -263,7 +263,7 @@ class TestAddAfterEOF:
         with pytest.raises(WatermarkingError, match="Unsupported MAC algorithm: 'HMAC-SHA512'"):
             method.read_secret(watermarked, "any-key")
     
-    @pytest.mark.xfail
+
     def test_missing_mac_algorithm_raises_error(self, sample_pdf_bytes: bytes):
         """Test missing MAC algorithm raises WatermarkingError."""
         method = AddAfterEOF()
@@ -278,7 +278,7 @@ class TestAddAfterEOF:
         with pytest.raises(WatermarkingError, match="Unsupported MAC algorithm: None"):
             method.read_secret(watermarked, "any-key")
     
-    @pytest.mark.xfail
+
     def test_missing_mac_field_raises_error(self, sample_pdf_bytes: bytes):
         """Test missing MAC field raises SecretNotFoundError."""
         method = AddAfterEOF()
@@ -293,7 +293,7 @@ class TestAddAfterEOF:
         with pytest.raises(SecretNotFoundError, match="Invalid payload fields"):
             method.read_secret(watermarked, "any-key")
     
-    @pytest.mark.xfail
+
     def test_missing_secret_field_raises_error(self, sample_pdf_bytes: bytes):
         """Test missing secret field raises SecretNotFoundError."""
         method = AddAfterEOF()
@@ -308,7 +308,7 @@ class TestAddAfterEOF:
         with pytest.raises(SecretNotFoundError, match="Invalid payload fields"):
             method.read_secret(watermarked, "any-key")
     
-    @pytest.mark.xfail
+
     def test_invalid_base64_secret_raises_error(self, sample_pdf_bytes: bytes):
         """Test invalid base64 secret raises SecretNotFoundError."""
         method = AddAfterEOF()
@@ -323,7 +323,7 @@ class TestAddAfterEOF:
         with pytest.raises(SecretNotFoundError, match="Invalid payload fields"):
             method.read_secret(watermarked, "any-key")
     
-    @pytest.mark.xfail
+
     def test_non_string_mac_field_raises_error(self, sample_pdf_bytes: bytes):
         """Test non-string MAC field raises SecretNotFoundError."""
         method = AddAfterEOF()
@@ -338,7 +338,7 @@ class TestAddAfterEOF:
         with pytest.raises(SecretNotFoundError, match="Invalid payload fields"):
             method.read_secret(watermarked, "any-key")
     
-    @pytest.mark.xfail
+
     def test_non_string_secret_field_raises_error(self, sample_pdf_bytes: bytes):
         """Test non-string secret field raises SecretNotFoundError."""
         method = AddAfterEOF()


### PR DESCRIPTION
在业务代码中：修改了路径，在 read_secret 方法中解析完JSON之后但在进行HMAC比较之前，增加对字段类型的检查。